### PR TITLE
Fix wake lock hook usage

### DIFF
--- a/lib/wake/mod.ts
+++ b/lib/wake/mod.ts
@@ -1,19 +1,19 @@
 import { useEffect } from "react";
 
 export function ReactWakeLock(
-  props: { onChanged?: (active: boolean) => void },
+  { onChanged }: { onChanged?: (active: boolean) => void },
 ) {
-  if (!("wakeLock" in navigator)) {
-    return;
-  }
-
   useEffect(() => {
+    if (!("wakeLock" in navigator)) {
+      return;
+    }
+
     let wakeLock: WakeLockSentinel | null = null;
 
     function handleLockRelease() {
       if (wakeLock !== null) {
         wakeLock = null;
-        props.onChanged?.(false);
+        onChanged?.(false);
       }
     }
 
@@ -22,7 +22,7 @@ export function ReactWakeLock(
         try {
           wakeLock = await navigator.wakeLock.request("screen");
           wakeLock.addEventListener("release", handleLockRelease);
-          props.onChanged?.(true);
+          onChanged?.(true);
         } catch (err) {
           console.error("Failed to acquire wake lock:", err);
         }
@@ -41,7 +41,7 @@ export function ReactWakeLock(
       }
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, []);
+  }, [onChanged]);
 
   return null;
 }

--- a/lib/wake/mod.ts
+++ b/lib/wake/mod.ts
@@ -3,8 +3,8 @@ import { useEffect } from "react";
 export function ReactWakeLock(
   { onChanged }: { onChanged?: (active: boolean) => void },
 ) {
-  useEffect(() => {
     if (!("wakeLock" in navigator)) {
+      onChanged?.(false);
       return;
     }
 


### PR DESCRIPTION
## Summary
- refactor ReactWakeLock to run effect unconditionally and handle unsupported wake lock API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `_session` is assigned a value but never used)


------
https://chatgpt.com/codex/tasks/task_e_68aaaf0c95b88327bcfe8abf9af1e891